### PR TITLE
Auto fetch fix

### DIFF
--- a/cron/freshrss
+++ b/cron/freshrss
@@ -1,1 +1,1 @@
-*/15 * * * * php /config/www/freshrss/app/actualize_script.php > /tmp/FreshRSS.log 2>&1
+* * * * * root /usr/bin/php /config/www/freshrss/app/actualize_script.php > /tmp/FreshRSS.log 2>&1

--- a/cron/freshrss
+++ b/cron/freshrss
@@ -1,1 +1,1 @@
-* * * * * root /usr/bin/php /config/www/freshrss/app/actualize_script.php > /tmp/FreshRSS.log 2>&1
+*/15 * * * * root /usr/bin/php /config/www/freshrss/app/actualize_script.php > /tmp/FreshRSS.log 2>&1


### PR DESCRIPTION
This PR changes the permissions of the freshrss cron file to 600, uses the full path for php binary and changes the syntax within the cron file (the username to run as was missing).

closes #2