### PR TITLE
internalize app, enable updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG BUILD_DATE
 ARG VERSION
 ARG FRESHRSS_RELEASE
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
-LABEL maintainer="sparklyballs"
+LABEL maintainer="aptalca"
 
 RUN \
  echo "**** install runtime packages ****" && \
@@ -26,12 +26,22 @@ RUN \
 	php7-sqlite3 \
 	php7-zip \
 	sqlite && \
- echo "**** Tag this image with current version ****" && \
+ echo "**** install app ****" && \
  if [ -z ${FRESHRSS_RELEASE+x} ]; then \
 	FRESHRSS_RELEASE=$(curl -sX GET "https://api.github.com/repos/FreshRSS/FreshRSS/releases/latest" \
 	| awk '/tag_name/{print $4;exit}' FS='[""]'); \
  fi && \
- echo ${FRESHRSS_RELEASE} > /version.txt
+ mkdir -p \
+	/usr/share/webapps/freshrss && \
+ curl -o \
+	/tmp/freshrss.tar.gz -L \
+	"https://github.com/FreshRSS/FreshRSS/archive/${FRESHRSS_RELEASE}.tar.gz" && \
+ tar xf \
+	/tmp/freshrss.tar.gz -C \
+	/usr/share/webapps/freshrss --strip-components=1 && \
+ echo "**** cleanup ****" && \
+ rm -rf \
+	/tmp/*
 
 # copy local files
 COPY root/ /

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,8 @@ RUN \
  tar xf \
 	/tmp/freshrss.tar.gz -C \
 	/usr/share/webapps/freshrss --strip-components=1 && \
+ sed -i "s|'disable_update' => false,|'disable_update' => true,|g" \
+	/usr/share/webapps/freshrss/config.default.php && \
  echo "**** cleanup ****" && \
  rm -rf \
 	/tmp/*

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -5,7 +5,7 @@ ARG BUILD_DATE
 ARG VERSION
 ARG FRESHRSS_RELEASE
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
-LABEL maintainer="sparklyballs"
+LABEL maintainer="aptalca"
 
 RUN \
  echo "**** install runtime packages ****" && \
@@ -26,12 +26,22 @@ RUN \
 	php7-sqlite3 \
 	php7-zip \
 	sqlite && \
- echo "**** Tag this image with current version ****" && \
+ echo "**** install app ****" && \
  if [ -z ${FRESHRSS_RELEASE+x} ]; then \
 	FRESHRSS_RELEASE=$(curl -sX GET "https://api.github.com/repos/FreshRSS/FreshRSS/releases/latest" \
 	| awk '/tag_name/{print $4;exit}' FS='[""]'); \
  fi && \
- echo ${FRESHRSS_RELEASE} > /version.txt
+ mkdir -p \
+	/usr/share/webapps/freshrss && \
+ curl -o \
+	/tmp/freshrss.tar.gz -L \
+	"https://github.com/FreshRSS/FreshRSS/archive/${FRESHRSS_RELEASE}.tar.gz" && \
+ tar xf \
+	/tmp/freshrss.tar.gz -C \
+	/usr/share/webapps/freshrss --strip-components=1 && \
+ echo "**** cleanup ****" && \
+ rm -rf \
+	/tmp/*
 
 # copy local files
 COPY root/ /

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -39,6 +39,8 @@ RUN \
  tar xf \
 	/tmp/freshrss.tar.gz -C \
 	/usr/share/webapps/freshrss --strip-components=1 && \
+ sed -i "s|'disable_update' => false,|'disable_update' => true,|g" \
+	/usr/share/webapps/freshrss/config.default.php && \
  echo "**** cleanup ****" && \
  rm -rf \
 	/tmp/*

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -5,7 +5,7 @@ ARG BUILD_DATE
 ARG VERSION
 ARG FRESHRSS_RELEASE
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
-LABEL maintainer="sparklyballs"
+LABEL maintainer="aptalca"
 
 RUN \
  echo "**** install runtime packages ****" && \
@@ -26,12 +26,22 @@ RUN \
 	php7-sqlite3 \
 	php7-zip \
 	sqlite && \
- echo "**** Tag this image with current version ****" && \
+ echo "**** install app ****" && \
  if [ -z ${FRESHRSS_RELEASE+x} ]; then \
 	FRESHRSS_RELEASE=$(curl -sX GET "https://api.github.com/repos/FreshRSS/FreshRSS/releases/latest" \
 	| awk '/tag_name/{print $4;exit}' FS='[""]'); \
  fi && \
- echo ${FRESHRSS_RELEASE} > /version.txt
+ mkdir -p \
+	/usr/share/webapps/freshrss && \
+ curl -o \
+	/tmp/freshrss.tar.gz -L \
+	"https://github.com/FreshRSS/FreshRSS/archive/${FRESHRSS_RELEASE}.tar.gz" && \
+ tar xf \
+	/tmp/freshrss.tar.gz -C \
+	/usr/share/webapps/freshrss --strip-components=1 && \
+ echo "**** cleanup ****" && \
+ rm -rf \
+	/tmp/*
 
 # copy local files
 COPY root/ /

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -39,6 +39,8 @@ RUN \
  tar xf \
 	/tmp/freshrss.tar.gz -C \
 	/usr/share/webapps/freshrss --strip-components=1 && \
+ sed -i "s|'disable_update' => false,|'disable_update' => true,|g" \
+	/usr/share/webapps/freshrss/config.default.php && \
  echo "**** cleanup ****" && \
  rm -rf \
 	/tmp/*

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ docker create \
   -e PGID=1000 \
   -e TZ=Europe/London \
   -p 80:80 \
-  -v <path to data>:/config \
+  -v /path/to/data:/config \
   --restart unless-stopped \
   linuxserver/freshrss
 ```
@@ -90,7 +90,7 @@ services:
       - PGID=1000
       - TZ=Europe/London
     volumes:
-      - <path to data>:/config
+      - /path/to/data:/config
     ports:
       - 80:80
     restart: unless-stopped
@@ -137,7 +137,11 @@ In this instance `PUID=1000` and `PGID=1000`, to find yours use `id user` as bel
 &nbsp;
 ## Application Setup
 
-Create a user and database in your mysql/mariadb server (not root) and then follow the setup wizard in the webui. Use the IP address for "host" of your database server.
+Access the webui set up wizard at `http://serverIP:port`
+
+For external databases, create a user and database in your mysql/mariadb server (not root) and then follow the setup wizard in the webui. Use the IP address for "host" of your database server.  
+
+Additional extensions can be dropped into `/config/www/freshrss/extensions` and will be active after container restart.
 
 
 
@@ -205,6 +209,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **07.01.19:** - Internalize app and enable updates for existing users.
 * **19.12.19:** - Rebasing to alpine 3.11.
 * **28.06.19:** - Rebasing to alpine 3.10.
 * **23.03.19:** - Switching to new Base images, shift to arm32v7 tag.

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
-* **07.01.19:** - Internalize app and enable updates for existing users.
+* **31.03.20:** - Internalize app and enable updates for existing users, allow user customized crontab.
 * **19.12.19:** - Rebasing to alpine 3.11.
 * **28.06.19:** - Rebasing to alpine 3.10.
 * **23.03.19:** - Switching to new Base images, shift to arm32v7 tag.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -26,7 +26,7 @@ param_env_vars:
   - { env_var: "TZ", env_value: "Europe/London", desc: "Specify a timezone to use EG Europe/London." }
 param_usage_include_vols: true
 param_volumes:
-  - { vol_path: "/config", vol_host_path: "<path to data>", desc: "Local storage for freshrss site files." }
+  - { vol_path: "/config", vol_host_path: "/path/to/data", desc: "Local storage for freshrss site files." }
 param_usage_include_ports: true
 param_ports:
   - { external_port: "80", internal_port: "80", port_desc: "WebUI" }
@@ -44,10 +44,15 @@ optional_block_1: false
 # application setup block
 app_setup_block_enabled: true
 app_setup_block: |
-  Create a user and database in your mysql/mariadb server (not root) and then follow the setup wizard in the webui. Use the IP address for "host" of your database server.
+  Access the webui set up wizard at `http://serverIP:port`
+  
+  For external databases, create a user and database in your mysql/mariadb server (not root) and then follow the setup wizard in the webui. Use the IP address for "host" of your database server.  
+
+  Additional extensions can be dropped into `/config/www/freshrss/extensions` and will be active after container restart.
 
 # changelog
 changelogs:
+  - { date: "07.01.19:", desc: "Internalize app and enable updates for existing users." }
   - { date: "19.12.19:", desc: "Rebasing to alpine 3.11." }
   - { date: "28.06.19:", desc: "Rebasing to alpine 3.10." }
   - { date: "23.03.19:", desc: "Switching to new Base images, shift to arm32v7 tag." }

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -52,7 +52,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
-  - { date: "07.01.19:", desc: "Internalize app and enable updates for existing users." }
+  - { date: "31.03.20:", desc: "Internalize app and enable updates for existing users, allow user customized crontab." }
   - { date: "19.12.19:", desc: "Rebasing to alpine 3.11." }
   - { date: "28.06.19:", desc: "Rebasing to alpine 3.10." }
   - { date: "23.03.19:", desc: "Switching to new Base images, shift to arm32v7 tag." }

--- a/root/defaults/default
+++ b/root/defaults/default
@@ -6,7 +6,7 @@ server {
 	ssl_certificate /config/keys/cert.crt;
 	ssl_certificate_key /config/keys/cert.key;
 	client_max_body_size 0;
-	root /config/www/freshrss/p;
+	root /usr/share/webapps/freshrss/p;
 	index index.php index.html index.htm;
 
 	location ~ ^.+?\.php(/.*)?$ {

--- a/root/defaults/freshrss
+++ b/root/defaults/freshrss
@@ -1,1 +1,0 @@
-*/15 * * * * /usr/bin/php7 /usr/share/webapps/freshrss/app/actualize_script.php > /tmp/FreshRSS.log 2>&1

--- a/root/defaults/freshrss
+++ b/root/defaults/freshrss
@@ -1,1 +1,1 @@
-*/15 * * * * /usr/bin/php7 /config/www/freshrss/app/actualize_script.php > /tmp/FreshRSS.log 2>&1
+*/15 * * * * /usr/bin/php7 /usr/share/webapps/freshrss/app/actualize_script.php > /tmp/FreshRSS.log 2>&1

--- a/root/defaults/root
+++ b/root/defaults/root
@@ -1,0 +1,9 @@
+# do daily/weekly/monthly maintenance
+# min   hour    day     month   weekday command
+*/15    *       *       *       *       run-parts /etc/periodic/15min
+0       *       *       *       *       run-parts /etc/periodic/hourly
+0       2       *       *       *       run-parts /etc/periodic/daily
+0       3       *       *       6       run-parts /etc/periodic/weekly
+0       5       1       *       *       run-parts /etc/periodic/monthly
+# freshrss cronjob
+*/15    *       *       *       *       /usr/bin/php7 /usr/share/webapps/freshrss/app/actualize_script.php > /tmp/FreshRSS.log 2>&1

--- a/root/etc/cont-init.d/40-install
+++ b/root/etc/cont-init.d/40-install
@@ -2,7 +2,7 @@
 
 # make our folders
 mkdir -p \
-	/config/www/freshrss
+	/config/{crontabs,www/freshrss}
 
 # create symlinks
 symlinks=( \
@@ -27,7 +27,9 @@ fi
 	sed -i "s|'disable_update' => false,|'disable_update' => true,|g" /config/www/freshrss/data/config.php
 
 # set cronjob
-crontab -u root /defaults/freshrss
+[[ ! -f /config/crontabs/root ]] && \
+	cp /defaults/root /config/crontabs/root
+cp /config/crontabs/root /etc/crontabs/root
 
 # permissions
 chown -R abc:abc \

--- a/root/etc/cont-init.d/40-install
+++ b/root/etc/cont-init.d/40-install
@@ -23,7 +23,8 @@ if grep -q 'root /config/www/freshrss/p;' /config/nginx/site-confs/default; then
 fi
 
 # disable updates
-sed -i "s|'disable_update' => false,|'disable_update' => true,|g" /config/www/freshrss/data/config.php
+[[ -f /config/www/freshrss/data/config.php ]] && \
+	sed -i "s|'disable_update' => false,|'disable_update' => true,|g" /config/www/freshrss/data/config.php
 
 # set cronjob
 crontab -u root /defaults/freshrss

--- a/root/etc/cont-init.d/40-install
+++ b/root/etc/cont-init.d/40-install
@@ -1,20 +1,31 @@
 #!/usr/bin/with-contenv bash
 
-# install freshrss
-[[ ! -f /config/www/freshrss/index.php ]] && \
-	FRESHRSS_RELEASE=$(cat /version.txt)
-	mkdir -p /config/www/freshrss/
-	curl -o \
-		/tmp/freshrss.tar.gz -L \
-		"https://github.com/FreshRSS/FreshRSS/archive/${FRESHRSS_RELEASE}.tar.gz"
-	tar xf \
-		/tmp/freshrss.tar.gz -C \
-		/config/www/freshrss/ --strip-components=1
-	rm -f /tmp/freshrss.tar.gz
+# make our folders
+mkdir -p \
+	/config/www/freshrss
+
+# create symlinks
+symlinks=( \
+/usr/share/webapps/freshrss/data \
+/usr/share/webapps/freshrss/extensions )
+
+for i in "${symlinks[@]}"
+do
+[[ -e "$i" && ! -L "$i" ]] && mv "$i" "${i}.bak"
+[[ ! -L "$i" ]] && ln -s "/config/www/freshrss/$(basename "$i")" "$i"
+[[ ! -d "/config/www/freshrss/$(basename "$i")" ]] && \
+	cp -R "${i}.bak" "/config/www/freshrss/$(basename "$i")"
+done
+
+# backwards compatibility
+if grep -q 'root /config/www/freshrss/p;' /config/nginx/site-confs/default; then 
+	cp /defaults/default /config/nginx/site-confs/default
+fi
 
 # set cronjob
 crontab -u root /defaults/freshrss
 
 # permissions
 chown -R abc:abc \
+	/usr/share/webapps/freshrss \
 	/config

--- a/root/etc/cont-init.d/40-install
+++ b/root/etc/cont-init.d/40-install
@@ -22,6 +22,9 @@ if grep -q 'root /config/www/freshrss/p;' /config/nginx/site-confs/default; then
 	cp /defaults/default /config/nginx/site-confs/default
 fi
 
+# disable updates
+sed -i "s|'disable_update' => false,|'disable_update' => true,|g" /config/www/freshrss/data/config.php
+
 # set cronjob
 crontab -u root /defaults/freshrss
 


### PR DESCRIPTION
This PR restructures the image, moving the app files to a path inside the image, and symlinking the data folders to /config, thereby enabling updates for existing users. Also disables gui updates.

Tested clean install and a basic update from an existing container with old style data