### PR TITLE
Increase php memory_limit to 256M

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,8 @@ RUN \
     /app/www --strip-components=1 && \
   sed -i "s|'disable_update' => false,|'disable_update' => true,|g" \
     /app/www/config.default.php && \
+  sed -i "s|memory_limit = 128M|memory_limit = 256M|g" \
+    /etc/php81/php.ini && \
   echo "**** cleanup ****" && \
   rm -rf \
     /tmp/*


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [ ] I have read the [contributing](https://github.com/linuxserver/docker-freshrss/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
I've been running into issues on a couple of Android apps (Read You, FreshRSS) where syncing is very slow or doesn't work at all.  Changing the `memory_limit` in `/etc/php81/php.ini` or `./config/php/php-local.ini` fixed the issue.

## Benefits of this PR and context:
Increased performance in mobile apps

## How Has This Been Tested?
· Downloaded both Read You and FreshRSS Android apps
· Logged in and forced a sync
· App error for FreshRSS is gone and articles are pulled.  Read You syncs much faster.

## Source / References:
https://gitlab.com/christophehenry/freshrss-android/-/issues/124#note_1382399590
